### PR TITLE
Fix retry exit handling

### DIFF
--- a/fetch_lifelogs_redacted.ps1
+++ b/fetch_lifelogs_redacted.ps1
@@ -92,7 +92,9 @@ do {
                 } else {
                     $exitReason = "Max retries ($maxRetries) reached for 504 errors"
                     Add-Content -Path $logFile -Value "[$timestamp] $exitReason. Exiting."
-                    exit
+                    $cursor = $null    # stop outer loop
+                    $success = $true  # exit retry loop
+                    break
                 }
             } else {
                 $exitReason = "Unexpected error: $_"


### PR DESCRIPTION
## Summary
- stop exiting early when retry limit hit
- let the script produce final stats

## Testing
- `pwsh -noprofile -command "Write-Host Hello"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684159bcd530832abbae9f4830036ece