### PR TITLE
Add Pester tests

### DIFF
--- a/tests/fetch_lifelogs_redacted.Tests.ps1
+++ b/tests/fetch_lifelogs_redacted.Tests.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = 'Stop'
+$scriptPath = Join-Path $PSScriptRoot '..' 'fetch_lifelogs_redacted.ps1'
+$lines = Get-Content $scriptPath
+$funcBlock = $lines[31..40] -join "`n"
+Invoke-Expression $funcBlock
+
+Describe 'Decode-Cursor' {
+    It 'returns decoded cursor value for valid input' {
+        $cursorValue = 'mycursor'
+        $json = @{ cursorValue = $cursorValue } | ConvertTo-Json -Compress
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+        Decode-Cursor -cursor $encoded | Should -Be $cursorValue
+    }
+
+    It 'returns failure message for invalid input' {
+        Decode-Cursor -cursor 'invalid' | Should -Be 'Failed to decode cursor'
+    }
+}


### PR DESCRIPTION
## Summary
- add a Pester test to verify `Decode-Cursor`

## Testing
- `Invoke-Pester -Path tests -EnableExit` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841640342e4832ab1cda44bd162d92e